### PR TITLE
VCST-4516: Move SEO blades from Core to Seo module

### DIFF
--- a/src/VirtoCommerce.Seo.Core/VirtoCommerce.Seo.Core.csproj
+++ b/src/VirtoCommerce.Seo.Core/VirtoCommerce.Seo.Core.csproj
@@ -7,6 +7,6 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.Seo.Data.MySql/VirtoCommerce.Seo.Data.MySql.csproj
+++ b/src/VirtoCommerce.Seo.Data.MySql/VirtoCommerce.Seo.Data.MySql.csproj
@@ -10,11 +10,11 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Seo.Data\VirtoCommerce.Seo.Data.csproj" />

--- a/src/VirtoCommerce.Seo.Data.PostgreSql/VirtoCommerce.Seo.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.Seo.Data.PostgreSql/VirtoCommerce.Seo.Data.PostgreSql.csproj
@@ -9,12 +9,12 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Seo.Data\VirtoCommerce.Seo.Data.csproj" />

--- a/src/VirtoCommerce.Seo.Data.SqlServer/VirtoCommerce.Seo.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.Seo.Data.SqlServer/VirtoCommerce.Seo.Data.SqlServer.csproj
@@ -9,11 +9,11 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Seo.Data\VirtoCommerce.Seo.Data.csproj" />

--- a/src/VirtoCommerce.Seo.Data/VirtoCommerce.Seo.Data.csproj
+++ b/src/VirtoCommerce.Seo.Data/VirtoCommerce.Seo.Data.csproj
@@ -7,8 +7,8 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Seo.Core\VirtoCommerce.Seo.Core.csproj" />

--- a/src/VirtoCommerce.Seo.Web/Localizations/de.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/de.VirtoCommerce.Seo.json
@@ -89,6 +89,51 @@
           "Final": "Stufe 6: Endgültig - Auswahl des ersten als aufgelöstes Seo."
         }
       },
+      "seo-list": {
+        "subtitle": "SEO verwalten",
+        "labels": {
+          "duplicates-found": "Warnung: Es gibt {{count}} widersprüchliche semantische URLs!",
+          "resolve-duplicates": "Konflikte lösen",
+          "language-code": "Sprache",
+          "container": "Shop",
+          "semanticUrl": "Semantische URL"
+        }
+      },
+      "seo-detail": {
+        "title-new": "Neues SEO",
+        "subtitle": "SEO-Details",
+        "labels": {
+          "is-active": "Aktiv",
+          "store": "Shop",
+          "language": "Sprache",
+          "url-keyword": "URL-Slug",
+          "page-title": "Seitentitel",
+          "meta-description": "Meta-Beschreibung",
+          "meta-keywords": "Meta-Schlüsselwörter",
+          "alternative-text": "Alternativer Bildtext"
+        },
+        "placeholders": {
+          "store": "Shop auswählen...",
+          "language": "Sprache auswählen...",
+          "url-keyword": "URL-Slug angeben...",
+          "page-title": "Titel angeben...",
+          "meta-description": "Beschreibung angeben...",
+          "meta-keywords": "Schlüsselwörter angeben...",
+          "alternative-text": "Alternativen Text angeben..."
+        },
+        "validations": {
+          "url-keyword-required": "Dieses Feld ist erforderlich",
+          "url-keyword-invalid": "Die URL enthält ungültige Zeichen",
+          "url-keyword-duplicate": "Doppelte URL erkannt"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "SEO-Konflikte",
+        "labels": {
+          "semanticUrl": "Semantische URL",
+          "container": "Shop"
+        }
+      },
       "seo-explain-items": {
         "title": "Elemente des SEO-Link-Debuggings",
         "labels": {
@@ -121,6 +166,10 @@
       "redirect-rule-save": {
         "title": "Änderungen speichern",
         "message": "Dieses Objekt wurde geändert. Möchten Sie die Änderungen speichern?"
+      },
+      "seo-save": {
+        "title": "Änderungen speichern",
+        "message": "Die SEO-Informationen wurden geändert. Möchten Sie die Änderungen speichern?"
       }
     },
     "widgets": {
@@ -132,6 +181,9 @@
       },
       "seo-explain-widget": {
         "title": "SEO-Links debuggen"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/de.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/de.VirtoCommerce.Seo.json
@@ -96,7 +96,8 @@
           "resolve-duplicates": "Konflikte lösen",
           "language-code": "Sprache",
           "container": "Shop",
-          "semanticUrl": "Semantische URL"
+          "semanticUrl": "Semantische URL",
+          "inactive": "Inaktiv"
         }
       },
       "seo-detail": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/en.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/en.VirtoCommerce.Seo.json
@@ -96,7 +96,8 @@
           "resolve-duplicates": "Resolve conflicts",
           "language-code": "Language",
           "container": "Store",
-          "semanticUrl": "Semantic URL"
+          "semanticUrl": "Semantic URL",
+          "inactive": "Inactive"
         }
       },
       "seo-detail": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/en.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/en.VirtoCommerce.Seo.json
@@ -89,6 +89,51 @@
           "Final": "Stage 6: Final - select first as the resolved Seo."
         }
       },
+      "seo-list": {
+        "subtitle": "Manage SEO",
+        "labels": {
+          "duplicates-found": "Warning: There are {{count}} conflicting semantic URLs!",
+          "resolve-duplicates": "Resolve conflicts",
+          "language-code": "Language",
+          "container": "Store",
+          "semanticUrl": "Semantic URL"
+        }
+      },
+      "seo-detail": {
+        "title-new": "New SEO",
+        "subtitle": "SEO details",
+        "labels": {
+          "is-active": "Active",
+          "store": "Store",
+          "language": "Language",
+          "url-keyword": "URL slug",
+          "page-title": "Page title",
+          "meta-description": "Meta description",
+          "meta-keywords": "Meta keywords",
+          "alternative-text": "Image alternative text"
+        },
+        "placeholders": {
+          "store": "Select store...",
+          "language": "Select language...",
+          "url-keyword": "Provide URL slug...",
+          "page-title": "Provide title...",
+          "meta-description": "Provide description...",
+          "meta-keywords": "Provide keywords...",
+          "alternative-text": "Provide alt text..."
+        },
+        "validations": {
+          "url-keyword-required": "This field is required",
+          "url-keyword-invalid": "The URL contains invalid characters",
+          "url-keyword-duplicate": "Duplicate URL detected"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "SEO conflicts",
+        "labels": {
+          "semanticUrl": "Semantic URL",
+          "container": "Store"
+        }
+      },
       "seo-explain-items": {
         "title": "Debug SEO links Items",
         "labels": {
@@ -121,6 +166,10 @@
       "redirect-rule-save": {
         "title": "Save changes",
         "message": "This entity has been modified. Do you want to save changes?"
+      },
+      "seo-save": {
+        "title": "Save changes",
+        "message": "The SEO information has been modified. Do you want to save changes?"
       }
     },
     "widgets": {
@@ -129,6 +178,12 @@
       },
       "redirect-rule-widget": {
         "title": "Active rules"
+      },
+      "seo-explain-widget": {
+        "title": "Debug SEO"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/es.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/es.VirtoCommerce.Seo.json
@@ -89,6 +89,51 @@
           "Final": "Etapa 6: Final - seleccionar el primero como el Seo resuelto."
         }
       },
+      "seo-list": {
+        "subtitle": "Gestionar SEO",
+        "labels": {
+          "duplicates-found": "Advertencia: ¡Hay {{count}} URL semánticas en conflicto!",
+          "resolve-duplicates": "Resolver conflictos",
+          "language-code": "Idioma",
+          "container": "Tienda",
+          "semanticUrl": "URL semántica"
+        }
+      },
+      "seo-detail": {
+        "title-new": "Nuevo SEO",
+        "subtitle": "Detalles de SEO",
+        "labels": {
+          "is-active": "Activo",
+          "store": "Tienda",
+          "language": "Idioma",
+          "url-keyword": "Slug de URL",
+          "page-title": "Título de la página",
+          "meta-description": "Meta descripción",
+          "meta-keywords": "Meta palabras clave",
+          "alternative-text": "Texto alternativo de la imagen"
+        },
+        "placeholders": {
+          "store": "Seleccionar tienda...",
+          "language": "Seleccionar idioma...",
+          "url-keyword": "Proporcionar slug de URL...",
+          "page-title": "Proporcionar título...",
+          "meta-description": "Proporcionar descripción...",
+          "meta-keywords": "Proporcionar palabras clave...",
+          "alternative-text": "Proporcionar texto alternativo..."
+        },
+        "validations": {
+          "url-keyword-required": "Este campo es obligatorio",
+          "url-keyword-invalid": "La URL contiene caracteres no válidos",
+          "url-keyword-duplicate": "Se ha detectado una URL duplicada"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "Conflictos de SEO",
+        "labels": {
+          "semanticUrl": "URL semántica",
+          "container": "Tienda"
+        }
+      },
       "seo-explain-items": {
         "title": "Elementos de depuración de enlaces SEO",
         "labels": {
@@ -121,6 +166,10 @@
       "redirect-rule-save": {
         "title": "Guardar cambios",
         "message": "Esta entidad ha sido modificada. ¿Quieres guardar los cambios?"
+      },
+      "seo-save": {
+        "title": "Guardar cambios",
+        "message": "La información de SEO ha sido modificada. ¿Desea guardar los cambios?"
       }
     },
     "widgets": {
@@ -132,6 +181,9 @@
       },
       "seo-explain-widget": {
         "title": "Depurar enlaces SEO"
+      },
+      "seo": {
+        "title": "SEO"
       }
     },
     "permissions": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/es.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/es.VirtoCommerce.Seo.json
@@ -96,7 +96,8 @@
           "resolve-duplicates": "Resolver conflictos",
           "language-code": "Idioma",
           "container": "Tienda",
-          "semanticUrl": "URL semántica"
+          "semanticUrl": "URL semántica",
+          "inactive": "Inactivo"
         }
       },
       "seo-detail": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/fi.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/fi.VirtoCommerce.Seo.json
@@ -89,6 +89,52 @@
           "Final": "Vaihe 6: Lopullinen - valitaan ensimmäinen ratkaistuksi Seoksi."
         }
       },
+      "seo-list": {
+        "subtitle": "SEO:n hallinta",
+        "labels": {
+          "duplicates-found": "Varoitus: löytyi {{count}} ristiriitaista semanttista URL-osoitetta!",
+          "resolve-duplicates": "Ratkaise ristiriidat",
+          "language-code": "Kieli",
+          "container": "Kauppa",
+          "semanticUrl": "Semanttinen URL",
+          "inactive": "Ei aktiivinen"
+        }
+      },
+      "seo-detail": {
+        "title-new": "Uusi SEO",
+        "subtitle": "SEO-tiedot",
+        "labels": {
+          "is-active": "Aktiivinen",
+          "store": "Kauppa",
+          "language": "Kieli",
+          "url-keyword": "URL-tunniste",
+          "page-title": "Sivun otsikko",
+          "meta-description": "Metakuvaus",
+          "meta-keywords": "Meta-avainsanat",
+          "alternative-text": "Kuvan vaihtoehtoinen teksti"
+        },
+        "placeholders": {
+          "store": "Valitse kauppa...",
+          "language": "Valitse kieli...",
+          "url-keyword": "Syötä URL-tunniste...",
+          "page-title": "Syötä otsikko...",
+          "meta-description": "Syötä kuvaus...",
+          "meta-keywords": "Syötä avainsanat...",
+          "alternative-text": "Syötä vaihtoehtoinen teksti..."
+        },
+        "validations": {
+          "url-keyword-required": "Tämä kenttä on pakollinen",
+          "url-keyword-invalid": "URL sisältää virheellisiä merkkejä",
+          "url-keyword-duplicate": "Sama URL havaittu"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "SEO-ristiriidat",
+        "labels": {
+          "semanticUrl": "Semanttinen URL",
+          "container": "Kauppa"
+        }
+      },
       "seo-explain-items": {
         "title": "SEO-linkkien virheenkorjauskohteet",
         "labels": {
@@ -121,6 +167,10 @@
       "redirect-rule-save": {
         "title": "Tallenna muutokset",
         "message": "Tätä kohdetta on muokattu. Haluatko tallentaa muutokset?"
+      },
+      "seo-save": {
+        "title": "Tallenna muutokset",
+        "message": "SEO-tietoja on muokattu. Haluatko tallentaa muutokset?"
       }
     },
     "widgets": {
@@ -132,6 +182,9 @@
       },
       "seo-explain-widget": {
         "title": "SEO-linkkien virheenkorjaus"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/fr.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/fr.VirtoCommerce.Seo.json
@@ -96,7 +96,8 @@
           "resolve-duplicates": "Résoudre les conflits",
           "language-code": "Langue",
           "container": "Magasin",
-          "semanticUrl": "URL sémantique"
+          "semanticUrl": "URL sémantique",
+          "inactive": "Inactif"
         }
       },
       "seo-detail": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/fr.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/fr.VirtoCommerce.Seo.json
@@ -89,6 +89,51 @@
           "Final": "Étape 6: Final - Sélectionner le premier comme Seo résolu."
         }
       },
+      "seo-list": {
+        "subtitle": "Gérer le SEO",
+        "labels": {
+          "duplicates-found": "Attention : Il y a {{count}} URL sémantiques en conflit !",
+          "resolve-duplicates": "Résoudre les conflits",
+          "language-code": "Langue",
+          "container": "Magasin",
+          "semanticUrl": "URL sémantique"
+        }
+      },
+      "seo-detail": {
+        "title-new": "Nouveau SEO",
+        "subtitle": "Détails SEO",
+        "labels": {
+          "is-active": "Actif",
+          "store": "Magasin",
+          "language": "Langue",
+          "url-keyword": "Slug URL",
+          "page-title": "Titre de la page",
+          "meta-description": "Meta description",
+          "meta-keywords": "Meta mots-clés",
+          "alternative-text": "Texte alternatif de l'image"
+        },
+        "placeholders": {
+          "store": "Sélectionner le magasin...",
+          "language": "Sélectionner la langue...",
+          "url-keyword": "Fournir le slug URL...",
+          "page-title": "Fournir le titre...",
+          "meta-description": "Fournir la description...",
+          "meta-keywords": "Fournir les mots-clés...",
+          "alternative-text": "Fournir le texte alternatif..."
+        },
+        "validations": {
+          "url-keyword-required": "Ce champ est obligatoire",
+          "url-keyword-invalid": "L'URL contient des caractères invalides",
+          "url-keyword-duplicate": "URL en double détectée"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "Conflits SEO",
+        "labels": {
+          "semanticUrl": "URL sémantique",
+          "container": "Magasin"
+        }
+      },
       "seo-explain-items": {
         "title": "Éléments de débogage des liens SEO",
         "labels": {
@@ -121,6 +166,10 @@
       "redirect-rule-save": {
         "title": "Enregistrer les modifications",
         "message": "Cette entité a été modifiée. Voulez-vous enregistrer les modifications ?"
+      },
+      "seo-save": {
+        "title": "Enregistrer les modifications",
+        "message": "Les informations SEO ont été modifiées. Voulez-vous enregistrer les modifications ?"
       }
     },
     "widgets": {
@@ -132,6 +181,9 @@
       },
       "seo-explain-widget": {
         "title": "Déboguer les liens SEO"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/it.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/it.VirtoCommerce.Seo.json
@@ -89,6 +89,51 @@
           "Final": "Fase 6: Finale - Selezionare il primo come Seo risolto."
         }
       },
+      "seo-list": {
+        "subtitle": "Gestisci SEO",
+        "labels": {
+          "duplicates-found": "Attenzione: Ci sono {{count}} URL semantici in conflitto!",
+          "resolve-duplicates": "Risolvi conflitti",
+          "language-code": "Lingua",
+          "container": "Negozio",
+          "semanticUrl": "URL semantico"
+        }
+      },
+      "seo-detail": {
+        "title-new": "Nuovo SEO",
+        "subtitle": "Dettagli SEO",
+        "labels": {
+          "is-active": "Attivo",
+          "store": "Negozio",
+          "language": "Lingua",
+          "url-keyword": "Slug URL",
+          "page-title": "Titolo della pagina",
+          "meta-description": "Meta descrizione",
+          "meta-keywords": "Meta parole chiave",
+          "alternative-text": "Testo alternativo dell'immagine"
+        },
+        "placeholders": {
+          "store": "Seleziona negozio...",
+          "language": "Seleziona lingua...",
+          "url-keyword": "Fornisci slug URL...",
+          "page-title": "Fornisci titolo...",
+          "meta-description": "Fornisci descrizione...",
+          "meta-keywords": "Fornisci parole chiave...",
+          "alternative-text": "Fornisci testo alternativo..."
+        },
+        "validations": {
+          "url-keyword-required": "Questo campo è obbligatorio",
+          "url-keyword-invalid": "L'URL contiene caratteri non validi",
+          "url-keyword-duplicate": "URL duplicato rilevato"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "Conflitti SEO",
+        "labels": {
+          "semanticUrl": "URL semantico",
+          "container": "Negozio"
+        }
+      },
       "seo-explain-items": {
         "title": "Elementi di debug dei link SEO",
         "labels": {
@@ -121,6 +166,10 @@
       "redirect-rule-save": {
         "title": "Salva modifiche",
         "message": "Questa entità è stata modificata. Vuoi salvare le modifiche?"
+      },
+      "seo-save": {
+        "title": "Salva modifiche",
+        "message": "Le informazioni SEO sono state modificate. Vuoi salvare le modifiche?"
       }
     },
     "widgets": {
@@ -132,6 +181,9 @@
       },
       "seo-explain-widget": {
         "title": "Debug dei link SEO"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/it.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/it.VirtoCommerce.Seo.json
@@ -96,7 +96,8 @@
           "resolve-duplicates": "Risolvi conflitti",
           "language-code": "Lingua",
           "container": "Negozio",
-          "semanticUrl": "URL semantico"
+          "semanticUrl": "URL semantico",
+          "inactive": "Inattivo"
         }
       },
       "seo-detail": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/ja.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/ja.VirtoCommerce.Seo.json
@@ -96,7 +96,8 @@
           "resolve-duplicates": "競合を解決",
           "language-code": "言語",
           "container": "ストア",
-          "semanticUrl": "セマンティックURL"
+          "semanticUrl": "セマンティックURL",
+          "inactive": "無効"
         }
       },
       "seo-detail": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/ja.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/ja.VirtoCommerce.Seo.json
@@ -89,6 +89,51 @@
           "Final": "ステージ6：最終 - 解決済みのSeoとして最初のものを選択。"
         }
       },
+      "seo-list": {
+        "subtitle": "SEOの管理",
+        "labels": {
+          "duplicates-found": "注意：{{count}}件の競合するセマンティックURLがあります！",
+          "resolve-duplicates": "競合を解決",
+          "language-code": "言語",
+          "container": "ストア",
+          "semanticUrl": "セマンティックURL"
+        }
+      },
+      "seo-detail": {
+        "title-new": "新しいSEO",
+        "subtitle": "SEOの詳細",
+        "labels": {
+          "is-active": "アクティブ",
+          "store": "ストア",
+          "language": "言語",
+          "url-keyword": "URLスラッグ",
+          "page-title": "ページタイトル",
+          "meta-description": "メタ説明",
+          "meta-keywords": "メタキーワード",
+          "alternative-text": "画像の代替テキスト"
+        },
+        "placeholders": {
+          "store": "ストアを選択...",
+          "language": "言語を選択...",
+          "url-keyword": "URLスラッグを提供...",
+          "page-title": "タイトルを提供...",
+          "meta-description": "説明を提供...",
+          "meta-keywords": "キーワードを提供...",
+          "alternative-text": "代替テキストを提供..."
+        },
+        "validations": {
+          "url-keyword-required": "このフィールドは必須です",
+          "url-keyword-invalid": "URLに無効な文字が含まれています",
+          "url-keyword-duplicate": "重複するURLが検出されました"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "SEOの競合",
+        "labels": {
+          "semanticUrl": "セマンティックURL",
+          "container": "ストア"
+        }
+      },
       "seo-explain-items": {
         "title": "SEOリンクのデバッグ項目",
         "labels": {
@@ -121,6 +166,10 @@
       "redirect-rule-save": {
         "title": "変更の保存",
         "message": "このエンティティが変更されました。変更を保存しますか？"
+      },
+      "seo-save": {
+        "title": "変更を保存",
+        "message": "SEO情報が変更されました。変更を保存しますか？"
       }
     },
     "widgets": {
@@ -132,6 +181,9 @@
       },
       "seo-explain-widget": {
         "title": "SEOリンクのデバッグ"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/no.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/no.VirtoCommerce.Seo.json
@@ -89,6 +89,52 @@
           "Final": "Trinn 6: Endelig - velg første som den løste Seo."
         }
       },
+      "seo-list": {
+        "subtitle": "Administrer SEO",
+        "labels": {
+          "duplicates-found": "Advarsel: Det er {{count}} motstridende semantiske URL-er!",
+          "resolve-duplicates": "Løs konflikter",
+          "language-code": "Språk",
+          "container": "Butikk",
+          "semanticUrl": "Semantisk URL",
+          "inactive": "Inaktiv"
+        }
+      },
+      "seo-detail": {
+        "title-new": "Ny SEO",
+        "subtitle": "SEO-detaljer",
+        "labels": {
+          "is-active": "Aktiv",
+          "store": "Butikk",
+          "language": "Språk",
+          "url-keyword": "URL-slug",
+          "page-title": "Sidetittel",
+          "meta-description": "Metabeskrivelse",
+          "meta-keywords": "Meta-nøkkelord",
+          "alternative-text": "Bildets alternativ tekst"
+        },
+        "placeholders": {
+          "store": "Velg butikk...",
+          "language": "Velg språk...",
+          "url-keyword": "Oppgi URL-slug...",
+          "page-title": "Oppgi tittel...",
+          "meta-description": "Oppgi beskrivelse...",
+          "meta-keywords": "Oppgi nøkkelord...",
+          "alternative-text": "Oppgi alternativ tekst..."
+        },
+        "validations": {
+          "url-keyword-required": "Dette feltet er påkrevd",
+          "url-keyword-invalid": "URL-en inneholder ugyldige tegn",
+          "url-keyword-duplicate": "Duplikat-URL oppdaget"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "SEO-konflikter",
+        "labels": {
+          "semanticUrl": "Semantisk URL",
+          "container": "Butikk"
+        }
+      },
       "seo-explain-items": {
         "title": "Feilsøkingselementer for SEO-lenker",
         "labels": {
@@ -121,6 +167,10 @@
       "redirect-rule-save": {
         "title": "Lagre endringer",
         "message": "Denne enheten har blitt endret. Vil du lagre endringene?"
+      },
+      "seo-save": {
+        "title": "Lagre endringer",
+        "message": "SEO-informasjonen er endret. Vil du lagre endringene?"
       }
     },
     "widgets": {
@@ -132,6 +182,9 @@
       },
       "seo-explain-widget": {
         "title": "Feilsøk SEO-lenker"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/pl.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/pl.VirtoCommerce.Seo.json
@@ -96,7 +96,8 @@
           "resolve-duplicates": "Rozwiąż konflikty",
           "language-code": "Język",
           "container": "Sklep",
-          "semanticUrl": "Semantyczny URL"
+          "semanticUrl": "Semantyczny URL",
+          "inactive": "Nieaktywny"
         }
       },
       "seo-detail": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/pl.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/pl.VirtoCommerce.Seo.json
@@ -89,6 +89,51 @@
           "Final": "Etap 6: Finał - wybór pierwszego jako rozwiązanego Seo."
         }
       },
+      "seo-list": {
+        "subtitle": "Zarządzaj SEO",
+        "labels": {
+          "duplicates-found": "Uwaga: Istnieje {{count}} konfliktowych semantycznych URL-i!",
+          "resolve-duplicates": "Rozwiąż konflikty",
+          "language-code": "Język",
+          "container": "Sklep",
+          "semanticUrl": "Semantyczny URL"
+        }
+      },
+      "seo-detail": {
+        "title-new": "Nowe SEO",
+        "subtitle": "Szczegóły SEO",
+        "labels": {
+          "is-active": "Aktywne",
+          "store": "Sklep",
+          "language": "Język",
+          "url-keyword": "Slug URL",
+          "page-title": "Tytuł strony",
+          "meta-description": "Meta opis",
+          "meta-keywords": "Meta słowa kluczowe",
+          "alternative-text": "Tekst alternatywny obrazu"
+        },
+        "placeholders": {
+          "store": "Wybierz sklep...",
+          "language": "Wybierz język...",
+          "url-keyword": "Podaj slug URL...",
+          "page-title": "Podaj tytuł...",
+          "meta-description": "Podaj opis...",
+          "meta-keywords": "Podaj słowa kluczowe...",
+          "alternative-text": "Podaj tekst alternatywny..."
+        },
+        "validations": {
+          "url-keyword-required": "To pole jest wymagane",
+          "url-keyword-invalid": "URL zawiera nieprawidłowe znaki",
+          "url-keyword-duplicate": "Wykryto zduplikowany URL"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "Konflikty SEO",
+        "labels": {
+          "semanticUrl": "Semantyczny URL",
+          "container": "Sklep"
+        }
+      },
       "seo-explain-items": {
         "title": "Elementy debugowania linków SEO",
         "labels": {
@@ -121,6 +166,10 @@
       "redirect-rule-save": {
         "title": "Zapisz zmiany",
         "message": "Ten obiekt został zmodyfikowany. Czy chcesz zapisać zmiany?"
+      },
+      "seo-save": {
+        "title": "Zapisz zmiany",
+        "message": "Informacje SEO zostały zmodyfikowane. Czy chcesz zapisać zmiany?"
       }
     },
     "widgets": {
@@ -132,6 +181,9 @@
       },
       "seo-explain-widget": {
         "title": "Debugowanie linków SEO"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/pt.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/pt.VirtoCommerce.Seo.json
@@ -89,6 +89,51 @@
           "Final": "Fase 6: Final - Selecionar o primeiro como o Seo resolvido."
         }
       },
+      "seo-list": {
+        "subtitle": "Gerenciar SEO",
+        "labels": {
+          "duplicates-found": "Atenção: Existem {{count}} URLs semânticas conflitantes!",
+          "resolve-duplicates": "Resolver conflitos",
+          "language-code": "Idioma",
+          "container": "Loja",
+          "semanticUrl": "URL semântica"
+        }
+      },
+      "seo-detail": {
+        "title-new": "Novo SEO",
+        "subtitle": "Detalhes do SEO",
+        "labels": {
+          "is-active": "Ativo",
+          "store": "Loja",
+          "language": "Idioma",
+          "url-keyword": "Slug da URL",
+          "page-title": "Título da página",
+          "meta-description": "Meta descrição",
+          "meta-keywords": "Meta palavras-chave",
+          "alternative-text": "Texto alternativo da imagem"
+        },
+        "placeholders": {
+          "store": "Selecionar loja...",
+          "language": "Selecionar idioma...",
+          "url-keyword": "Fornecer slug da URL...",
+          "page-title": "Fornecer título...",
+          "meta-description": "Fornecer descrição...",
+          "meta-keywords": "Fornecer palavras-chave...",
+          "alternative-text": "Fornecer texto alternativo..."
+        },
+        "validations": {
+          "url-keyword-required": "Este campo é obrigatório",
+          "url-keyword-invalid": "A URL contém caracteres inválidos",
+          "url-keyword-duplicate": "URL duplicada detectada"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "Conflitos de SEO",
+        "labels": {
+          "semanticUrl": "URL semântica",
+          "container": "Loja"
+        }
+      },
       "seo-explain-items": {
         "title": "Itens de depuração de links de SEO",
         "labels": {
@@ -121,6 +166,10 @@
       "redirect-rule-save": {
         "title": "Guardar alterações",
         "message": "Esta entidade foi modificada. Deseja guardar as alterações?"
+      },
+      "seo-save": {
+        "title": "Salvar alterações",
+        "message": "As informações de SEO foram modificadas. Deseja salvar as alterações?"
       }
     },
     "widgets": {
@@ -132,6 +181,9 @@
       },
       "seo-explain-widget": {
         "title": "Depurar links de SEO"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/pt.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/pt.VirtoCommerce.Seo.json
@@ -96,7 +96,8 @@
           "resolve-duplicates": "Resolver conflitos",
           "language-code": "Idioma",
           "container": "Loja",
-          "semanticUrl": "URL semântica"
+          "semanticUrl": "URL semântica",
+          "inactive": "Inativo"
         }
       },
       "seo-detail": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/ru.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/ru.VirtoCommerce.Seo.json
@@ -89,6 +89,51 @@
           "Final": "Этап 6: Финальный - выбор первого в качестве разрешенного Seo."
         }
       },
+      "seo-list": {
+        "subtitle": "Управление SEO",
+        "labels": {
+          "duplicates-found": "Внимание! Найдено {{count}} конфликтующих семантических URL!",
+          "resolve-duplicates": "Разрешить конфликты",
+          "language-code": "Язык",
+          "container": "Магазин",
+          "semanticUrl": "Семантический URL"
+        }
+      },
+      "seo-detail": {
+        "title-new": "Новое SEO",
+        "subtitle": "Информация о SEO",
+        "labels": {
+          "is-active": "Активно",
+          "store": "Магазин",
+          "language": "Язык",
+          "url-keyword": "URL-слаг",
+          "page-title": "Заголовок страницы",
+          "meta-description": "Мета-описание",
+          "meta-keywords": "Мета-ключевые слова",
+          "alternative-text": "Альтернативный текст изображения"
+        },
+        "placeholders": {
+          "store": "Выберите магазин...",
+          "language": "Выберите язык...",
+          "url-keyword": "Укажите URL-слаг...",
+          "page-title": "Укажите заголовок...",
+          "meta-description": "Укажите описание...",
+          "meta-keywords": "Укажите ключевые слова...",
+          "alternative-text": "Укажите альтернативный текст..."
+        },
+        "validations": {
+          "url-keyword-required": "Это поле обязательно",
+          "url-keyword-invalid": "URL содержит недопустимые символы",
+          "url-keyword-duplicate": "Обнаружен дубликат URL"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "Конфликты SEO",
+        "labels": {
+          "semanticUrl": "Семантический URL",
+          "container": "Магазин"
+        }
+      },
       "seo-explain-items": {
         "title": "Элементы отладки SEO-ссылок",
         "labels": {
@@ -121,6 +166,10 @@
       "redirect-rule-save": {
         "title": "Сохранить изменения",
         "message": "Этот объект был изменен. Хотите сохранить изменения?"
+      },
+      "seo-save": {
+        "title": "Сохранить изменения",
+        "message": "Информация SEO была изменена. Хотите сохранить изменения?"
       }
     },
     "widgets": {
@@ -132,6 +181,9 @@
       },
       "seo-explain-widget": {
         "title": "Отладка SEO-ссылок"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/ru.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/ru.VirtoCommerce.Seo.json
@@ -96,7 +96,8 @@
           "resolve-duplicates": "Разрешить конфликты",
           "language-code": "Язык",
           "container": "Магазин",
-          "semanticUrl": "Семантический URL"
+          "semanticUrl": "Семантический URL",
+          "inactive": "Неактивен"
         }
       },
       "seo-detail": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/sv.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/sv.VirtoCommerce.Seo.json
@@ -89,6 +89,52 @@
           "Final": "Steg 6: Slutlig - välj första som den lösta Seo."
         }
       },
+      "seo-list": {
+        "subtitle": "Hantera SEO",
+        "labels": {
+          "duplicates-found": "Varning: Det finns {{count}} motstridiga semantiska URL:er!",
+          "resolve-duplicates": "Lös konflikter",
+          "language-code": "Språk",
+          "container": "Butik",
+          "semanticUrl": "Semantisk URL",
+          "inactive": "Inaktiv"
+        }
+      },
+      "seo-detail": {
+        "title-new": "Ny SEO",
+        "subtitle": "SEO-detaljer",
+        "labels": {
+          "is-active": "Aktiv",
+          "store": "Butik",
+          "language": "Språk",
+          "url-keyword": "URL-slug",
+          "page-title": "Sidtitel",
+          "meta-description": "Metabeskrivning",
+          "meta-keywords": "Meta-nyckelord",
+          "alternative-text": "Bildens alternativa text"
+        },
+        "placeholders": {
+          "store": "Välj butik...",
+          "language": "Välj språk...",
+          "url-keyword": "Ange URL-slug...",
+          "page-title": "Ange titel...",
+          "meta-description": "Ange beskrivning...",
+          "meta-keywords": "Ange nyckelord...",
+          "alternative-text": "Ange alternativ text..."
+        },
+        "validations": {
+          "url-keyword-required": "Detta fält är obligatoriskt",
+          "url-keyword-invalid": "URL:en innehåller ogiltiga tecken",
+          "url-keyword-duplicate": "Dubblett-URL upptäckt"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "SEO-konflikter",
+        "labels": {
+          "semanticUrl": "Semantisk URL",
+          "container": "Butik"
+        }
+      },
       "seo-explain-items": {
         "title": "Felsökningsobjekt för SEO-länkar",
         "labels": {
@@ -121,6 +167,10 @@
       "redirect-rule-save": {
         "title": "Spara ändringar",
         "message": "Denna entitet har ändrats. Vill du spara ändringarna?"
+      },
+      "seo-save": {
+        "title": "Spara ändringar",
+        "message": "SEO-informationen har ändrats. Vill du spara ändringarna?"
       }
     },
     "widgets": {
@@ -132,6 +182,9 @@
       },
       "seo-explain-widget": {
         "title": "Felsök SEO-länkar"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Localizations/zh.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/zh.VirtoCommerce.Seo.json
@@ -96,7 +96,8 @@
           "resolve-duplicates": "解决冲突",
           "language-code": "语言",
           "container": "商店",
-          "semanticUrl": "语义URL"
+          "semanticUrl": "语义URL",
+          "inactive": "未启用"
         }
       },
       "seo-detail": {

--- a/src/VirtoCommerce.Seo.Web/Localizations/zh.VirtoCommerce.Seo.json
+++ b/src/VirtoCommerce.Seo.Web/Localizations/zh.VirtoCommerce.Seo.json
@@ -89,6 +89,51 @@
           "Final": "阶段 6: 最终 - 选择第一个作为已解析的Seo。"
         }
       },
+      "seo-list": {
+        "subtitle": "管理SEO",
+        "labels": {
+          "duplicates-found": "注意：存在 {{count}} 个冲突的语义URL！",
+          "resolve-duplicates": "解决冲突",
+          "language-code": "语言",
+          "container": "商店",
+          "semanticUrl": "语义URL"
+        }
+      },
+      "seo-detail": {
+        "title-new": "新建SEO",
+        "subtitle": "SEO详情",
+        "labels": {
+          "is-active": "活跃",
+          "store": "商店",
+          "language": "语言",
+          "url-keyword": "URL别名",
+          "page-title": "页面标题",
+          "meta-description": "元描述",
+          "meta-keywords": "元关键词",
+          "alternative-text": "图片替代文本"
+        },
+        "placeholders": {
+          "store": "选择商店...",
+          "language": "选择语言...",
+          "url-keyword": "提供URL别名...",
+          "page-title": "提供标题...",
+          "meta-description": "提供描述...",
+          "meta-keywords": "提供关键词...",
+          "alternative-text": "提供替代文本..."
+        },
+        "validations": {
+          "url-keyword-required": "此字段为必填项",
+          "url-keyword-invalid": "URL包含无效字符",
+          "url-keyword-duplicate": "检测到重复的URL"
+        }
+      },
+      "seo-duplicates": {
+        "subtitle": "SEO冲突",
+        "labels": {
+          "semanticUrl": "语义URL",
+          "container": "商店"
+        }
+      },
       "seo-explain-items": {
         "title": "调试SEO链接项目",
         "labels": {
@@ -121,6 +166,10 @@
       "redirect-rule-save": {
         "title": "保存更改",
         "message": "此实体已被修改。您想保存更改吗？"
+      },
+      "seo-save": {
+        "title": "保存更改",
+        "message": "SEO信息已被修改。您想保存更改吗？"
       }
     },
     "widgets": {
@@ -132,6 +181,9 @@
       },
       "seo-explain-widget": {
         "title": "调试SEO链接"
+      },
+      "seo": {
+        "title": "SEO"
       }
     }
   },

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-detail.html
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-detail.html
@@ -1,0 +1,77 @@
+<div class="blade-static __bottom" ng-include="'$(Platform)/Scripts/common/templates/ok-cancel.tpl.html'"></div>
+<div class="blade-content">
+    <div class="blade-inner">
+        <div class="inner-block">
+            <form name="formScope" class="form">
+                <div>
+                    <label class="form-label">{{'seo.blades.seo-detail.labels.is-active' | translate}}</label>
+                    <div class="form-input">
+                        <label class="form-label __switch">
+                            <input type="checkbox" ng-model="blade.currentEntity.isActive" />
+                            <span class="switch"></span>
+                        </label>
+                    </div>
+                </div>
+                <div class="form-group" ng-if="!blade.fixedStoreId && storeDataSource">
+                    <label class="form-label">{{'seo.blades.seo-detail.labels.store' | translate}}</label>
+                    <div class="form-input">
+                        <ui-scroll-drop-down data="storeDataSource(criteria)"
+                                             placeholder="'seo.blades.seo-detail.placeholders.store'"
+                                             ng-model="blade.currentEntity.storeId">
+                        </ui-scroll-drop-down>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">{{'seo.blades.seo-detail.labels.language' | translate}}</label>
+                    <div class="form-input">
+                        <ui-select ng-model="blade.currentEntity.languageCode">
+                            <ui-select-match allow-clear placeholder="{{'seo.blades.seo-detail.placeholders.language' | translate}}">{{$select.selected}}</ui-select-match>
+                            <ui-select-choices repeat="x in blade.languages">
+                                <span ng-if="x.length>2" class="flag flag-{{x.substr(3).toLowerCase()}}"></span>
+                                <span ng-if="x.length<=2" class="langCode">{{x.toUpperCase()}}</span>
+                                <span ng-bind-html="x"></span>
+                            </ui-select-choices>
+                        </ui-select>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">{{'seo.blades.seo-detail.labels.url-keyword' | translate}}</label>
+                    <div class="form-input">
+                        <input ng-model="blade.currentEntity.semanticUrl" name="semanticUrl" required ui-validate="{invalidUrl:'semanticUrlValidator($value)'}" ui-validate-watch="'blade.currentEntity.storeId'" placeholder="{{'seo.blades.seo-detail.placeholders.url-keyword' | translate}}" autocomplete="off" />
+                    </div>
+                    <div class="form-error" ng-show="formScope.semanticUrl.$dirty">
+                        <span ng-show="formScope.semanticUrl.$error.required">{{'seo.blades.seo-detail.validations.url-keyword-required' | translate}}</span>
+                        <span ng-show="formScope.semanticUrl.$error.invalidUrl">{{'seo.blades.seo-detail.validations.url-keyword-invalid' | translate}}</span>
+                        <span ng-show="!duplicateValidator(blade.currentEntity.semanticUrl)">{{'seo.blades.seo-detail.validations.url-keyword-duplicate' | translate}}</span>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">{{'seo.blades.seo-detail.labels.page-title' | translate}}</label>
+                    <div class="form-input">
+                        <input ng-model="blade.currentEntity.pageTitle" class="form-control" placeholder="{{'seo.blades.seo-detail.placeholders.page-title' | translate}}" />
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">{{'seo.blades.seo-detail.labels.meta-description' | translate}}</label>
+                    <div class="form-input">
+                        <textarea ng-model="blade.currentEntity.metaDescription" class="form-control" cols="30" rows="3" placeholder="{{'seo.blades.seo-detail.placeholders.meta-description' | translate}}"></textarea>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">{{'seo.blades.seo-detail.labels.meta-keywords' | translate}}</label>
+                    <div class="form-input">
+                        <input ng-model="blade.currentEntity.metaKeywords" class="form-control" ng-maxlength="255" placeholder="{{'seo.blades.seo-detail.placeholders.meta-keywords' | translate}}" />
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">{{'seo.blades.seo-detail.labels.alternative-text' | translate}}</label>
+                    <div class="form-input">
+                        <input ng-model="blade.currentEntity.imageAltDescription" class="form-control" placeholder="{{'seo.blades.seo-detail.placeholders.alternative-text' | translate}}" />
+                    </div>
+                </div>
+
+                <va-metaform registered-inputs="blade.metaFields" blade="blade"></va-metaform>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-detail.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-detail.js
@@ -1,7 +1,7 @@
 angular.module('virtoCommerce.seo')
     .controller('virtoCommerce.seo.seoDetailController',
-        ['$scope', 'platformWebApp.bladeNavigationService', 'platformWebApp.metaFormsService',
-            function ($scope, bladeNavigationService, metaFormsService) {
+        ['$scope', 'platformWebApp.bladeNavigationService', 'platformWebApp.metaFormsService', 'virtoCommerce.seo.seoUtils',
+            function ($scope, bladeNavigationService, metaFormsService, seoUtils) {
                 const blade = $scope.blade;
 
                 function initializeBlade() {
@@ -43,10 +43,7 @@ angular.module('virtoCommerce.seo')
                         $scope.semanticUrlValidator(data.semanticUrl);
                 }
 
-                $scope.semanticUrlValidator = function (value) {
-                    const pattern = /[$+;=%{}[\]|\\/@ ~#!^*&?:'<>,]/;
-                    return !pattern.test(value);
-                };
+                $scope.semanticUrlValidator = seoUtils.isValidSemanticUrl;
 
                 $scope.duplicateValidator = function (value) {
                     return _.all(blade.seoContainerObject.seoInfos, function (x) {

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-detail.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-detail.js
@@ -44,7 +44,7 @@ angular.module('virtoCommerce.seo')
                 }
 
                 $scope.semanticUrlValidator = function (value) {
-                    const pattern = /[$+;=%{}[\]|@ ~#!^*&?:'<>,]/;
+                    const pattern = /[$+;=%{}[\]|\\/@ ~#!^*&?:'<>,]/;
                     return !pattern.test(value);
                 };
 

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-detail.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-detail.js
@@ -1,0 +1,92 @@
+angular.module('virtoCommerce.seo')
+    .controller('virtoCommerce.seo.seoDetailController',
+        ['$scope', 'platformWebApp.bladeNavigationService', 'platformWebApp.metaFormsService',
+            function ($scope, bladeNavigationService, metaFormsService) {
+                const blade = $scope.blade;
+
+                function initializeBlade() {
+                    blade.origEntity = blade.data;
+                    blade.currentEntity = angular.copy(blade.origEntity);
+                    blade.isLoading = false;
+                }
+
+                blade.metaFields = metaFormsService.getMetaFields("seoDetails");
+                $scope.storeDataSource = blade.storeDataSource || undefined;
+
+                $scope.cancelChanges = function () {
+                    angular.copy(blade.origEntity, blade.currentEntity);
+                    $scope.bladeClose();
+                };
+
+                $scope.saveChanges = function () {
+                    if (blade.isNew) {
+                        if (!blade.seoContainerObject.seoInfos) {
+                            blade.seoContainerObject.seoInfos = [];
+                        }
+                        blade.seoContainerObject.seoInfos.push(blade.currentEntity);
+                    }
+
+                    angular.copy(blade.currentEntity, blade.origEntity);
+                    if (!blade.noClose) {
+                        $scope.bladeClose();
+                    }
+                }
+
+                function saveChanges_noClose() {
+                    blade.noClose = true;
+                    $scope.saveChanges();
+                }
+
+                function isValid(data) {
+                    // check required and valid Url requirements
+                    return data.semanticUrl &&
+                        $scope.semanticUrlValidator(data.semanticUrl);
+                }
+
+                $scope.semanticUrlValidator = function (value) {
+                    const pattern = /[$+;=%{}[\]|@ ~#!^*&?:'<>,]/;
+                    return !pattern.test(value);
+                };
+
+                $scope.duplicateValidator = function (value) {
+                    return _.all(blade.seoContainerObject.seoInfos, function (x) {
+                        return x === blade.origEntity ||
+                            x.storeId !== blade.currentEntity.storeId ||
+                            x.semanticUrl !== value;
+                    });
+                };
+
+                function isDirty() {
+                    return !angular.equals(blade.currentEntity, blade.origEntity) && blade.hasUpdatePermission();
+                }
+
+                function canSave() {
+                    return (blade.isNew || isDirty()) && isValid(blade.currentEntity);
+                }
+
+                $scope.isValid = canSave;
+
+                blade.onClose = function (closeCallback) {
+                    bladeNavigationService.showConfirmationIfNeeded(
+                        isDirty(), canSave(), blade, saveChanges_noClose, closeCallback,
+                        "seo.dialogs.seo-save.title", "seo.dialogs.seo-save.message");
+                };
+
+                blade.toolbarCommands = [
+                    {
+                        name: "platform.commands.reset", icon: 'fa fa-undo',
+                        executeMethod: function () {
+                            angular.copy(blade.origEntity, blade.currentEntity);
+                        },
+                        canExecuteMethod: isDirty,
+                        permission: blade.updatePermission
+                    }
+                ];
+
+                blade.headIcon = 'fa fa-globe';
+                blade.title = blade.isNew ? 'seo.blades.seo-detail.title-new' : blade.data.semanticUrl;
+                blade.subtitle = 'seo.blades.seo-detail.subtitle';
+
+                initializeBlade();
+            }]);
+

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.html
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.html
@@ -1,0 +1,39 @@
+<div class="blade-content">
+    <div class="blade-inner">
+        <div class="inner-block">
+            <div class="table-wrapper">
+                <form name="formScope" class="form">
+                    <table class="table" ng-init="setForm(formScope)">
+                        <thead>
+                            <tr>
+                                <th class="table-col">{{ 'seo.blades.seo-duplicates.labels.semanticUrl' | translate }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="table-item" ng-repeat-start="data in blade.currentEntities" ng-class="{'__selected': blade.selectedNodeId===data.id}" ng-click="blade.selectedNodeId = data.id">
+                                <td class="table-head" colspan="1">
+                                    <span>{{data.objectType}}: {{data.name}}</span>
+                                </td>
+                            </tr>
+                            <tr class="table-item" ng-repeat-end ng-class="{'__selected': blade.selectedNodeId===data.id}" ng-click="blade.selectedNodeId = data.id">
+                                <td class="table-col">
+                                    <ng-form name="valuesForm">
+                                        <div class="form-input">
+                                            <input ng-model="data.semanticUrl" required ui-validate="{invalidUrl: 'semanticUrlValidator($value)'}" name="semanticUrl" placeholder="{{'seo.blades.seo-detail.placeholders.url-keyword' | translate}}" autocomplete="off" />
+                                        </div>
+                                        <div class="form-error">
+                                            <span ng-show="valuesForm.semanticUrl.$error.required">{{'seo.blades.seo-detail.validations.url-keyword-required' | translate}}</span>
+                                            <span ng-show="valuesForm.semanticUrl.$error.invalidUrl">{{'seo.blades.seo-detail.validations.url-keyword-invalid' | translate}}</span>
+                                            <span ng-show="blade.conflicts[data.id]">{{'seo.blades.seo-detail.validations.url-keyword-duplicate' | translate}}</span>
+                                        </div>
+
+                                    </ng-form>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.js
@@ -1,115 +1,119 @@
 angular.module('virtoCommerce.seo')
-    .controller('virtoCommerce.seo.seoDuplicatesController', ['$rootScope', '$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.seo.seoApi', function ($rootScope, $scope, bladeNavigationService, seoApi) {
-        const blade = $scope.blade;
-        let anyValidSeoFound;
+    .controller('virtoCommerce.seo.seoDuplicatesController',
+        ['$rootScope', '$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.seo.seoApi',
+            function ($rootScope, $scope, bladeNavigationService, seoApi) {
+                const blade = $scope.blade;
+                let anyValidSeoFound;
 
-        function initializeBlade() {
-            blade.origEntity = blade.duplicates;
-            blade.currentEntities = angular.copy(blade.origEntity);
-            blade.isLoading = false;
-        };
-
-        function validate(data) {
-            // check all restrictions
-            const isUrlValid = data.semanticUrl && $scope.semanticUrlValidator(data.semanticUrl);
-            const retVal = isUrlValid && $scope.duplicateValidator(data.semanticUrl, data);
-            if (isUrlValid && !retVal) {
-                blade.conflicts[data.id] = true;
-            }
-            anyValidSeoFound = anyValidSeoFound || retVal;
-            return retVal;
-        }
-
-        $scope.semanticUrlValidator = function (value) {
-            const pattern = /[$+;=%{}[\]|\\/@ ~#!^*&?:'<>,]/;
-            return !pattern.test(value);
-        };
-
-        $scope.duplicateValidator = function (value, seoInfo) {
-            return _.all(blade.currentEntities, function (x) {
-                return x === seoInfo ||
-                    x.storeId !== seoInfo.storeId ||
-                    x.semanticUrl !== value;
-            });
-        };
-
-        $scope.saveChanges = function () {
-            blade.isLoading = true;
-
-            // generate data to save
-            const dataToSave = [];
-            _.each(blade.currentEntities, function (x) {
-                if (validate(x) &&
-                    !angular.equals(x, _.findWhere(blade.origEntity, { id: x.id }))) {
-                    x = angular.copy(x);
-                    if (!x.storeId) {
-                        x.id = undefined;
-                        x.storeId = blade.defaultContainerId;
-                    }
-                    dataToSave.push(x);
+                function initializeBlade() {
+                    blade.origEntity = blade.duplicates;
+                    blade.currentEntities = angular.copy(blade.origEntity);
+                    blade.isLoading = false;
                 }
-            });
 
-            seoApi.batchUpdate(dataToSave, function () {
-                angular.copy(blade.currentEntities, blade.origEntity);
-
-                seoApi.query({ objectId: blade.seoContainerObject.id, objectType: blade.objectType }, function (results) {
-                    if (_.any(results)) { // conflicts still found
-                        blade.duplicates = results;
-                        initializeBlade();
-                    } else {
-                        if (!blade.noClose) {
-                            $scope.bladeClose();
-                        }
-                        $rootScope.$broadcast("refresh-entity-by-id", blade.seoContainerObject.id);
+                function validate(data) {
+                    // check all restrictions
+                    const isUrlValid = data.semanticUrl && $scope.semanticUrlValidator(data.semanticUrl);
+                    const retVal = isUrlValid && $scope.duplicateValidator(data.semanticUrl, data);
+                    if (isUrlValid && !retVal) {
+                        blade.conflicts[data.id] = true;
                     }
-                });
-            }, function (error) { bladeNavigationService.setError('Error: ' + error.status, blade); });
-        };
+                    anyValidSeoFound = anyValidSeoFound || retVal;
+                    return retVal;
+                }
 
-        function saveChanges_noClose() {
-            blade.noClose = true;
-            $scope.saveChanges();
-        }
+                $scope.semanticUrlValidator = function (value) {
+                    const pattern = /[$+;=%{}[\]|\\/@ ~#!^*&?:'<>,]/;
+                    return !pattern.test(value);
+                };
 
-        function isDirty() {
-            return !angular.equals(blade.currentEntities, blade.origEntity) && blade.hasUpdatePermission();
-        }
+                $scope.duplicateValidator = function (value, seoInfo) {
+                    return _.all(blade.currentEntities, function (x) {
+                        return x === seoInfo ||
+                            x.storeId !== seoInfo.storeId ||
+                            x.semanticUrl !== value;
+                    });
+                };
 
-        function canSave() {
-            return isDirty() && anyValidSeoFound;
-        }
+                $scope.saveChanges = function () {
+                    blade.isLoading = true;
 
-        blade.onClose = function (closeCallback) {
-            bladeNavigationService.showConfirmationIfNeeded(isDirty(), canSave(), blade, saveChanges_noClose, closeCallback, "seo.dialogs.seo-save.title", "seo.dialogs.seo-save.message");
-        };
+                    // generate data to save
+                    const dataToSave = [];
+                    _.each(blade.currentEntities, function (x) {
+                        if (validate(x) &&
+                            !angular.equals(x, _.findWhere(blade.origEntity, { id: x.id }))) {
+                            x = angular.copy(x);
+                            if (!x.storeId) {
+                                x.id = undefined;
+                                x.storeId = blade.defaultContainerId;
+                            }
+                            dataToSave.push(x);
+                        }
+                    });
 
-        blade.toolbarCommands = [
-            {
-                name: "platform.commands.save", icon: 'fas fa-save',
-                executeMethod: $scope.saveChanges,
-                canExecuteMethod: canSave,
-                permission: blade.updatePermission
-            },
-            {
-                name: "platform.commands.reset", icon: 'fa fa-undo',
-                executeMethod: function () {
-                    angular.copy(blade.origEntity, blade.currentEntities);
-                },
-                canExecuteMethod: isDirty,
-                permission: blade.updatePermission
-            }
-        ];
+                    seoApi.batchUpdate(dataToSave, function () {
+                        angular.copy(blade.currentEntities, blade.origEntity);
 
-        blade.title = blade.parentBlade.title;
-        blade.subtitle = 'seo.blades.seo-duplicates.subtitle';
+                        seoApi.query({ objectId: blade.seoContainerObject.id, objectType: blade.objectType }, function (results) {
+                            if (_.any(results)) { // conflicts still found
+                                blade.duplicates = results;
+                                initializeBlade();
+                            } else {
+                                if (!blade.noClose) {
+                                    $scope.bladeClose();
+                                }
+                                $rootScope.$broadcast("refresh-entity-by-id", blade.seoContainerObject.id);
+                            }
+                        });
+                    }, function (error) { bladeNavigationService.setError('Error: ' + error.status, blade); });
+                };
 
-        initializeBlade();
+                function saveChanges_noClose() {
+                    blade.noClose = true;
+                    $scope.saveChanges();
+                }
 
-        $scope.$watch('blade.currentEntities', function () {
-            blade.conflicts = {};
-            anyValidSeoFound = false;
-            // must check ALL SEOs
-            _.each(blade.currentEntities, validate);
-        }, true);
-    }]);
+                function isDirty() {
+                    return !angular.equals(blade.currentEntities, blade.origEntity) && blade.hasUpdatePermission();
+                }
+
+                function canSave() {
+                    return isDirty() && anyValidSeoFound;
+                }
+
+                blade.onClose = function (closeCallback) {
+                    bladeNavigationService.showConfirmationIfNeeded(
+                        isDirty(), canSave(), blade, saveChanges_noClose, closeCallback,
+                        "seo.dialogs.seo-save.title", "seo.dialogs.seo-save.message");
+                };
+
+                blade.toolbarCommands = [
+                    {
+                        name: "platform.commands.save", icon: 'fas fa-save',
+                        executeMethod: $scope.saveChanges,
+                        canExecuteMethod: canSave,
+                        permission: blade.updatePermission
+                    },
+                    {
+                        name: "platform.commands.reset", icon: 'fa fa-undo',
+                        executeMethod: function () {
+                            angular.copy(blade.origEntity, blade.currentEntities);
+                        },
+                        canExecuteMethod: isDirty,
+                        permission: blade.updatePermission
+                    }
+                ];
+
+                blade.title = blade.parentBlade.title;
+                blade.subtitle = 'seo.blades.seo-duplicates.subtitle';
+
+                initializeBlade();
+
+                $scope.$watch('blade.currentEntities', function () {
+                    blade.conflicts = {};
+                    anyValidSeoFound = false;
+                    // must check ALL SEOs
+                    _.each(blade.currentEntities, validate);
+                }, true);
+            }]);

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.js
@@ -102,6 +102,10 @@ angular.module('virtoCommerce.seo')
                     }
                 ];
 
+                $scope.setForm = function (form) {
+                    blade.formScope = form;
+                };
+
                 blade.title = blade.parentBlade.title;
                 blade.subtitle = 'seo.blades.seo-duplicates.subtitle';
 

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.js
@@ -1,7 +1,7 @@
 angular.module('virtoCommerce.seo')
     .controller('virtoCommerce.seo.seoDuplicatesController',
-        ['$rootScope', '$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.seo.seoApi',
-            function ($rootScope, $scope, bladeNavigationService, seoApi) {
+        ['$rootScope', '$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.seo.seoApi', 'virtoCommerce.seo.seoUtils',
+            function ($rootScope, $scope, bladeNavigationService, seoApi, seoUtils) {
                 const blade = $scope.blade;
                 let anyValidSeoFound;
 
@@ -22,10 +22,7 @@ angular.module('virtoCommerce.seo')
                     return retVal;
                 }
 
-                $scope.semanticUrlValidator = function (value) {
-                    const pattern = /[$+;=%{}[\]|\\/@ ~#!^*&?:'<>,]/;
-                    return !pattern.test(value);
-                };
+                $scope.semanticUrlValidator = seoUtils.isValidSemanticUrl;
 
                 $scope.duplicateValidator = function (value, seoInfo) {
                     return _.all(blade.currentEntities, function (x) {

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.js
@@ -62,7 +62,7 @@ angular.module('virtoCommerce.seo')
                                 }
                                 $rootScope.$broadcast("refresh-entity-by-id", blade.seoContainerObject.id);
                             }
-                        });
+                        }, function (error) { bladeNavigationService.setError('Error: ' + error.status, blade); });
                     }, function (error) { bladeNavigationService.setError('Error: ' + error.status, blade); });
                 };
 

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-duplicates.js
@@ -1,0 +1,115 @@
+angular.module('virtoCommerce.seo')
+    .controller('virtoCommerce.seo.seoDuplicatesController', ['$rootScope', '$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.seo.seoApi', function ($rootScope, $scope, bladeNavigationService, seoApi) {
+        const blade = $scope.blade;
+        let anyValidSeoFound;
+
+        function initializeBlade() {
+            blade.origEntity = blade.duplicates;
+            blade.currentEntities = angular.copy(blade.origEntity);
+            blade.isLoading = false;
+        };
+
+        function validate(data) {
+            // check all restrictions
+            const isUrlValid = data.semanticUrl && $scope.semanticUrlValidator(data.semanticUrl);
+            const retVal = isUrlValid && $scope.duplicateValidator(data.semanticUrl, data);
+            if (isUrlValid && !retVal) {
+                blade.conflicts[data.id] = true;
+            }
+            anyValidSeoFound = anyValidSeoFound || retVal;
+            return retVal;
+        }
+
+        $scope.semanticUrlValidator = function (value) {
+            const pattern = /[$+;=%{}[\]|\\/@ ~#!^*&?:'<>,]/;
+            return !pattern.test(value);
+        };
+
+        $scope.duplicateValidator = function (value, seoInfo) {
+            return _.all(blade.currentEntities, function (x) {
+                return x === seoInfo ||
+                    x.storeId !== seoInfo.storeId ||
+                    x.semanticUrl !== value;
+            });
+        };
+
+        $scope.saveChanges = function () {
+            blade.isLoading = true;
+
+            // generate data to save
+            const dataToSave = [];
+            _.each(blade.currentEntities, function (x) {
+                if (validate(x) &&
+                    !angular.equals(x, _.findWhere(blade.origEntity, { id: x.id }))) {
+                    x = angular.copy(x);
+                    if (!x.storeId) {
+                        x.id = undefined;
+                        x.storeId = blade.defaultContainerId;
+                    }
+                    dataToSave.push(x);
+                }
+            });
+
+            seoApi.batchUpdate(dataToSave, function () {
+                angular.copy(blade.currentEntities, blade.origEntity);
+
+                seoApi.query({ objectId: blade.seoContainerObject.id, objectType: blade.objectType }, function (results) {
+                    if (_.any(results)) { // conflicts still found
+                        blade.duplicates = results;
+                        initializeBlade();
+                    } else {
+                        if (!blade.noClose) {
+                            $scope.bladeClose();
+                        }
+                        $rootScope.$broadcast("refresh-entity-by-id", blade.seoContainerObject.id);
+                    }
+                });
+            }, function (error) { bladeNavigationService.setError('Error: ' + error.status, blade); });
+        };
+
+        function saveChanges_noClose() {
+            blade.noClose = true;
+            $scope.saveChanges();
+        }
+
+        function isDirty() {
+            return !angular.equals(blade.currentEntities, blade.origEntity) && blade.hasUpdatePermission();
+        }
+
+        function canSave() {
+            return isDirty() && anyValidSeoFound;
+        }
+
+        blade.onClose = function (closeCallback) {
+            bladeNavigationService.showConfirmationIfNeeded(isDirty(), canSave(), blade, saveChanges_noClose, closeCallback, "seo.dialogs.seo-save.title", "seo.dialogs.seo-save.message");
+        };
+
+        blade.toolbarCommands = [
+            {
+                name: "platform.commands.save", icon: 'fas fa-save',
+                executeMethod: $scope.saveChanges,
+                canExecuteMethod: canSave,
+                permission: blade.updatePermission
+            },
+            {
+                name: "platform.commands.reset", icon: 'fa fa-undo',
+                executeMethod: function () {
+                    angular.copy(blade.origEntity, blade.currentEntities);
+                },
+                canExecuteMethod: isDirty,
+                permission: blade.updatePermission
+            }
+        ];
+
+        blade.title = blade.parentBlade.title;
+        blade.subtitle = 'seo.blades.seo-duplicates.subtitle';
+
+        initializeBlade();
+
+        $scope.$watch('blade.currentEntities', function () {
+            blade.conflicts = {};
+            anyValidSeoFound = false;
+            // must check ALL SEOs
+            _.each(blade.currentEntities, validate);
+        }, true);
+    }]);

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.html
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.html
@@ -41,7 +41,7 @@
     <div class="ui-grid-cell-contents">
         <div class="inner-contents">
             <div class="table-t">{{COL_FIELD}}</div>
-            <span class="table-status" ng-if="!row.entity.isActive">Inactive</span>
+            <span class="table-status" ng-if="!row.entity.isActive">{{'seo.blades.seo-list.labels.inactive' | translate}}</span>
         </div>
     </div>
 </script>

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.html
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.html
@@ -1,0 +1,47 @@
+<div class="blade-content">
+    <div class="blade-inner">
+        <div class="inner-block">
+            <div class="note error" ng-if="blade.duplicates.length">
+                {{'seo.blades.seo-list.labels.duplicates-found' | translate : {count: blade.duplicates.length-1} }}
+                <br />
+                <br />
+                <button class="btn" ng-click="resolveDuplicates()">{{ 'seo.blades.seo-list.labels.resolve-duplicates' | translate }}</button>
+            </div>
+            <div class="table-wrapper" ng-if="blade.currentEntities.length" ng-init="setGridOptions({
+                    rowTemplate: 'list.row.html',
+                    rowHeight: 60,
+                    columnDefs: [
+                                { name: 'actions', displayName: '', enableColumnResizing: false, enableSorting: false, width: 30, cellTemplate: 'list-actions.cell.html', pinnedLeft:true },
+                                { name: 'languageCode', displayName: 'seo.blades.seo-list.labels.language-code', sort: { direction: uiGridConstants.ASC }, width: 75 },
+                                { name: 'semanticUrl', displayName: 'seo.blades.seo-list.labels.semanticUrl', cellTemplate: 'list-semanticUrl.cell.html' },
+                                { name: 'storeId', displayName: 'seo.blades.seo-list.labels.container' }
+                        ]})">
+                <div ui-grid="gridOptions" ui-grid-auto-resize ui-grid-save-state ui-grid-selection ui-grid-resize-columns ui-grid-move-columns ui-grid-pinning ui-grid-height></div>
+                <ul class="menu __context" role="menu" id="sel_menu">
+                    <li class="menu-item" ng-click='delete(contextMenuEntity)' va-permission="{{blade.updatePermission}}">
+                        <i class="menu-ico fas fa-trash-alt"></i> {{'platform.commands.delete' | translate}}
+                    </li>
+                </ul>
+            </div>
+            <p class="note" ng-if="!blade.currentEntities.length">{{'platform.list.no-data' | translate}}</p>
+        </div>
+    </div>
+</div>
+
+<script type="text/ng-template" id="list.row.html">
+    <div ng-click="grid.appScope.blade.selectNode(row.entity)" ng-repeat="(colRenderIndex, col) in colContainer.renderedColumns track by col.uid" ui-grid-one-bind-id-grid="rowRenderIndex + '-' + col.uid + '-cell'" class="ui-grid-cell" ng-class="{'ui-grid-row-header-cell': col.isRowHeader, '__hovered': grid.appScope.contextMenuEntity === row.entity, '__selected': row.entity.id===grid.appScope.selectedNodeId }" role="{{col.isRowHeader ? 'rowheader' : 'gridcell'}}" ui-grid-cell context-menu="grid.appScope.contextMenuEntity = row.entity" data-target="sel_menu"></div>
+</script>
+<script type="text/ng-template" id="list-actions.cell.html">
+    <div class="ui-grid-actions" left-click-menu="grid.appScope.contextMenuEntity = row.entity" data-target="sel_menu">
+        <i class="fa fa-ellipsis-v"></i>
+    </div>
+</script>
+
+<script type="text/ng-template" id="list-semanticUrl.cell.html">
+    <div class="ui-grid-cell-contents">
+        <div class="inner-contents">
+            <div class="table-t">{{COL_FIELD}}</div>
+            <span class="table-status" ng-if="!row.entity.isActive">Inactive</span>
+        </div>
+    </div>
+</script>

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.html
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.html
@@ -19,7 +19,7 @@
                 <div ui-grid="gridOptions" ui-grid-auto-resize ui-grid-save-state ui-grid-selection ui-grid-resize-columns ui-grid-move-columns ui-grid-pinning ui-grid-height></div>
                 <ul class="menu __context" role="menu" id="sel_menu">
                     <li class="menu-item" ng-click='delete(contextMenuEntity)' va-permission="{{blade.updatePermission}}">
-                        <i class="menu-ico fas fa-trash-alt"></i> {{'platform.commands.delete' | translate}}
+                        <span class="menu-ico fas fa-trash-alt"></span> {{'platform.commands.delete' | translate}}
                     </li>
                 </ul>
             </div>
@@ -33,7 +33,7 @@
 </script>
 <script type="text/ng-template" id="list-actions.cell.html">
     <div class="ui-grid-actions" left-click-menu="grid.appScope.contextMenuEntity = row.entity" data-target="sel_menu">
-        <i class="fa fa-ellipsis-v"></i>
+        <span class="fa fa-ellipsis-v"></span>
     </div>
 </script>
 

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.js
@@ -1,8 +1,9 @@
 angular.module('virtoCommerce.seo')
     .controller('virtoCommerce.seo.seoListController',
-        ['$scope', 'platformWebApp.uiGridHelper', 'platformWebApp.bladeNavigationService', 'platformWebApp.dialogService',
-            function ($scope, uiGridHelper, bladeNavigationService, dialogService) {
+        ['$scope', 'platformWebApp.uiGridHelper', 'platformWebApp.bladeNavigationService', 'platformWebApp.dialogService', 'uiGridConstants',
+            function ($scope, uiGridHelper, bladeNavigationService, dialogService, uiGridConstants) {
                 const blade = $scope.blade;
+                $scope.uiGridConstants = uiGridConstants;
                 $scope.selectedNodeId = null; // need to initialize to null
 
                 blade.refresh = function (seoContainerObject) {

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.js
@@ -20,6 +20,7 @@ angular.module('virtoCommerce.seo')
                         seoContainerObject: blade.seoContainerObject,
                         defaultContainerId: blade.defaultContainerId,
                         languages: blade.languages,
+                        updatePermission: blade.updatePermission,
                         controller: 'virtoCommerce.seo.seoDuplicatesController',
                         template: 'Modules/$(VirtoCommerce.Seo)/Scripts/blades/seo-duplicates.html'
                     };

--- a/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/blades/seo-list.js
@@ -1,0 +1,112 @@
+angular.module('virtoCommerce.seo')
+    .controller('virtoCommerce.seo.seoListController',
+        ['$scope', 'platformWebApp.uiGridHelper', 'platformWebApp.bladeNavigationService', 'platformWebApp.dialogService',
+            function ($scope, uiGridHelper, bladeNavigationService, dialogService) {
+                const blade = $scope.blade;
+                $scope.selectedNodeId = null; // need to initialize to null
+
+                blade.refresh = function (seoContainerObject) {
+                    if (seoContainerObject) {
+                        blade.seoContainerObject = seoContainerObject;
+                        blade.currentEntities = blade.seoContainerObject.seoInfos;
+                    }
+                };
+
+                $scope.resolveDuplicates = function () {
+                    const newBlade = {
+                        id: 'seoDuplicates',
+                        duplicates: blade.duplicates,
+                        objectType: blade.objectType,
+                        seoContainerObject: blade.seoContainerObject,
+                        defaultContainerId: blade.defaultContainerId,
+                        languages: blade.languages,
+                        controller: 'virtoCommerce.seo.seoDuplicatesController',
+                        template: 'Modules/$(VirtoCommerce.Seo)/Scripts/blades/seo-duplicates.html'
+                    };
+
+                    if (blade.fixedStoreId) {
+                        newBlade.stores = [blade.seoContainerObject];
+                    }
+
+                    bladeNavigationService.showBlade(newBlade, blade);
+                };
+
+                blade.selectNode = openDetailsBlade;
+
+                function openDetailsBlade(node, isNew) {
+                    $scope.selectedNodeId = node.id;
+
+                    const newBlade = {
+                        id: 'seoDetails',
+                        data: node,
+                        isNew: isNew,
+                        seoContainerObject: blade.seoContainerObject,
+                        languages: blade.languages,
+                        storeDataSource: blade.storeDataSource,
+                        updatePermission: blade.updatePermission,
+                        controller: 'virtoCommerce.seo.seoDetailController',
+                        template: 'Modules/$(VirtoCommerce.Seo)/Scripts/blades/seo-detail.html'
+                    };
+
+                    newBlade.fixedStoreId = blade.fixedStoreId;
+                    bladeNavigationService.showBlade(newBlade, blade);
+                }
+
+                $scope.delete = function (data) {
+                    deleteList([data]);
+                };
+
+                function removeItems(selection) {
+                    _.each(selection, function (x) {
+                        blade.seoContainerObject.seoInfos.splice(blade.seoContainerObject.seoInfos.indexOf(x), 1);
+                    });
+                }
+
+                function deleteList(selection) {
+                    const dialog = {
+                        id: "confirmDelete",
+                        title: "platform.dialogs.delete.title",
+                        message: "platform.dialogs.delete.message",
+                        callback: function (remove) {
+                            if (remove) {
+                                bladeNavigationService.closeChildrenBlades(blade, function () {
+                                    removeItems(selection);
+                                });
+                            }
+                        }
+                    };
+                    dialogService.showConfirmationDialog(dialog);
+                }
+
+                blade.toolbarCommands = [
+                    {
+                        name: "platform.commands.add", icon: 'fas fa-plus',
+                        executeMethod: function () {
+                            bladeNavigationService.closeChildrenBlades(blade, function () {
+                                openDetailsBlade({ isActive: true }, true);
+                            });
+                        },
+                        canExecuteMethod: function () { return true; },
+                        permission: blade.updatePermission
+                    },
+                    {
+                        name: "platform.commands.delete", icon: 'fas fa-trash-alt',
+                        executeMethod: function () { deleteList($scope.gridApi.selection.getSelectedRows()); },
+                        canExecuteMethod: function () {
+                            return $scope.gridApi && _.any($scope.gridApi.selection.getSelectedRows()) && _.any(blade.seoContainerObject.seoInfos);
+                        },
+                        permission: blade.updatePermission
+                    }
+                ];
+
+                // ui-grid
+                $scope.setGridOptions = function (gridOptions) {
+                    uiGridHelper.initialize($scope, gridOptions);
+                };
+
+                blade.headIcon = 'fa fa-globe';
+                blade.subtitle = 'seo.blades.seo-list.subtitle';
+
+                blade.refresh(blade.seoContainerObject);
+                blade.isLoading = false;
+            }]);

--- a/src/VirtoCommerce.Seo.Web/Scripts/resources/seo-api.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/resources/seo-api.js
@@ -1,0 +1,6 @@
+angular.module('virtoCommerce.seo')
+    .factory('virtoCommerce.seo.seoApi', ['$resource', function ($resource) {
+        return $resource('api/seoinfos/duplicates', null, {
+            batchUpdate: { url: 'api/seoinfos/batchupdate', method: 'PUT' }
+        });
+    }]);

--- a/src/VirtoCommerce.Seo.Web/Scripts/utils/seo-utils.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/utils/seo-utils.js
@@ -1,0 +1,10 @@
+angular.module('virtoCommerce.seo')
+    .factory('virtoCommerce.seo.seoUtils', function () {
+        const invalidUrlPattern = /[$+;=%{}[\]|\\/@ ~#!^*&?:'<>,]/;
+
+        return {
+            isValidSemanticUrl: function (value) {
+                return !invalidUrlPattern.test(value);
+            }
+        };
+    });

--- a/src/VirtoCommerce.Seo.Web/Scripts/widgets/seo-widget.html
+++ b/src/VirtoCommerce.Seo.Web/Scripts/widgets/seo-widget.html
@@ -1,6 +1,6 @@
 <div class="gridster-cnt" ng-click="openSeoBlade()">
     <div class="cnt-inner">
-        <i class="fas fa-chart-bar fa-2x fa-gray"></i>
+        <span class="fas fa-chart-bar fa-2x fa-gray"></span>
         <div class="list-t">{{ 'seo.widgets.seo.title' | translate }}</div>
     </div>
 </div>

--- a/src/VirtoCommerce.Seo.Web/Scripts/widgets/seo-widget.html
+++ b/src/VirtoCommerce.Seo.Web/Scripts/widgets/seo-widget.html
@@ -1,0 +1,6 @@
+<div class="gridster-cnt" ng-click="openSeoBlade()">
+    <div class="cnt-inner">
+        <i class="fas fa-chart-bar fa-2x fa-gray"></i>
+        <div class="list-t">{{ 'seo.widgets.seo.title' | translate }}</div>
+    </div>
+</div>

--- a/src/VirtoCommerce.Seo.Web/Scripts/widgets/seo-widget.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/widgets/seo-widget.js
@@ -1,0 +1,42 @@
+angular.module('virtoCommerce.seo')
+    .controller('virtoCommerce.seo.seoWidgetController',
+        ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.seo.seoApi',
+            function ($scope, bladeNavigationService, seoApi) {
+                const blade = $scope.blade;
+                let promise;
+
+                $scope.openSeoBlade = function () {
+                    if (promise) {
+                        promise.then(openBlade);
+                    } else {
+                        openBlade();
+                    }
+                };
+
+                function openBlade(duplicates) {
+                    const newBlade = {
+                        id: "seoList",
+                        title: blade.title,
+                        duplicates: duplicates,
+                        objectType: $scope.widget.objectType,
+                        seoContainerObject: $scope.data,
+                        fixedStoreId: $scope.widget.getFixedStoreId ? $scope.widget.getFixedStoreId(blade) : undefined,
+                        defaultContainerId: $scope.widget.getDefaultContainerId(blade),
+                        languages: $scope.widget.getLanguages(blade),
+                        storeDataSource: $scope.widget.getStoreDataSource ? $scope.widget.getStoreDataSource(blade) : undefined,
+                        updatePermission: blade.updatePermission,
+                        controller: 'virtoCommerce.seo.seoListController',
+                        template: 'Modules/$(VirtoCommerce.Seo)/Scripts/blades/seo-list.html'
+                    };
+                    bladeNavigationService.showBlade(newBlade, blade);
+                }
+
+                $scope.$watch('data', function (data) {
+                    if (data && $scope.widget.getDefaultContainerId(blade)) {
+                        promise = seoApi.query({ objectId: data.id, objectType: $scope.widget.objectType }).$promise;
+                        promise.then(function (promiseData) {
+                            $scope.widget.UIclass = _.any(promiseData) ? 'error' : '';
+                        });
+                    }
+                });
+            }]);

--- a/src/VirtoCommerce.Seo.Web/Scripts/widgets/seo-widget.js
+++ b/src/VirtoCommerce.Seo.Web/Scripts/widgets/seo-widget.js
@@ -7,7 +7,7 @@ angular.module('virtoCommerce.seo')
 
                 $scope.openSeoBlade = function () {
                     if (promise) {
-                        promise.then(openBlade);
+                        promise.then(openBlade, function () { openBlade(); });
                     } else {
                         openBlade();
                     }

--- a/src/VirtoCommerce.Seo.Web/module.manifest
+++ b/src/VirtoCommerce.Seo.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1002.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1016.0</platformVersion>
   <dependencies>
   </dependencies>
 


### PR DESCRIPTION
## Description

- Moved SEO frontend (blades, widget, resource, localizations) from VirtoCommerce.Core to VirtoCommerce.Seo module
- Replaced direct storeApi injection with `getStoreDataSource` callback passed through widget config, removing the dependency on Store module
- Fixed missing `seo.widgets.seo-explain-widget.title` localization key in English
- Added `seo-api.js` resource for SEO duplicates API

### Moved files

| From (Core) | To (Seo) |
|---|---|
| `Scripts/SEO/blades/seo-detail.*` | `Scripts/blades/seo-detail.*` |
| `Scripts/SEO/blades/seo-list.*` | `Scripts/blades/seo-list.*` |
| `Scripts/SEO/blades/seo-duplicates.*` | `Scripts/blades/seo-duplicates.*` |
| `Scripts/SEO/widgets/seoWidget.*` | `Scripts/widgets/seo-widget.*` |
| `Scripts/SEO/resources/seoResource.js` | `Scripts/resources/seo-api.js` |

### Breaking changes for consumers

Modules that register the SEO widget must update:
- Controller: `virtoCommerce.coreModule.seo.seoWidgetController` → `virtoCommerce.seo.seoWidgetController`
- Template: `Modules/$(VirtoCommerce.Core)/Scripts/SEO/widgets/seoWidget.tpl.html` → `Modules/$(VirtoCommerce.Seo)/Scripts/widgets/seo-widget.html`
- New optional callback: `getStoreDataSource` for store dropdown in SEO detail blade

Companion PRs required in: vc-module-core, vc-module-catalog, vc-module-store, vc-module-customer, vc-module-catalog-publishing, vc-docs

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4516
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Seo_3.1002.0-pr-19-15be.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to consumer-facing breaking changes (new widget controller/template IDs and optional store data source callback) plus platform/EF Core package version bumps that may affect module compatibility.
> 
> **Overview**
> Moves the SEO management UI (*list/detail/duplicate-resolution blades* and the SEO dashboard widget) into the `VirtoCommerce.Seo` module and wires it to a new Angular `$resource` (`seoApi`) for duplicate detection and `batchUpdate` conflict resolution.
> 
> Updates localizations across languages for the new blades/dialogs/widgets (including the missing `seo.widgets.seo-explain-widget.title` in English) and introduces a `getStoreDataSource` callback path to avoid a direct Store-module dependency.
> 
> Bumps `VirtoCommerce.Platform.*` dependencies to `3.1016.0` (and EF Core design packages to `10.0.5`) and raises the module’s declared `platformVersion` to `3.1016.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15be734475be0da5890eb7b1f6d72002716c564a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->