### PR TITLE
VCST-4885: Mark GetSeoBySlug as obsolete

### DIFF
--- a/src/VirtoCommerce.Seo.Web/Controllers/Api/SeoController.cs
+++ b/src/VirtoCommerce.Seo.Web/Controllers/Api/SeoController.cs
@@ -54,6 +54,7 @@ public class SeoController(
     /// Find all SEO records for object by slug
     /// </summary>
     /// <param name="slug">slug</param>
+    [Obsolete("Use POST /api/seoinfos/search instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     [HttpGet]
     [Route("{slug}")]
     [Authorize(ModuleConstants.Security.Permissions.Read)]


### PR DESCRIPTION
## Description

Recommend using POST /api/seoinfos/search instead

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4885
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Seo_3.1002.0-pr-20-8158.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds an `Obsolete` attribute to an existing endpoint and does not change runtime behavior, aside from compiler warnings for consumers.
> 
> **Overview**
> Marks `GET /api/seoinfos/{slug}` (`GetSeoInfoBySlug`) as **obsolete**, directing callers to use `POST /api/seoinfos/search` instead (with diagnostic metadata `VC0014` and docs link). No functional behavior of the endpoint implementation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8158a74927d53bfca9578d010a1cb8a2d512a8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->