### PR TITLE
VCST-5163: Stable 15 — Seo (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.Seo.Core/VirtoCommerce.Seo.Core.csproj
+++ b/src/VirtoCommerce.Seo.Core/VirtoCommerce.Seo.Core.csproj
@@ -7,6 +7,6 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.Seo.Data.MySql/VirtoCommerce.Seo.Data.MySql.csproj
+++ b/src/VirtoCommerce.Seo.Data.MySql/VirtoCommerce.Seo.Data.MySql.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Seo.Data\VirtoCommerce.Seo.Data.csproj" />

--- a/src/VirtoCommerce.Seo.Data.PostgreSql/VirtoCommerce.Seo.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.Seo.Data.PostgreSql/VirtoCommerce.Seo.Data.PostgreSql.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Seo.Data\VirtoCommerce.Seo.Data.csproj" />

--- a/src/VirtoCommerce.Seo.Data.SqlServer/VirtoCommerce.Seo.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.Seo.Data.SqlServer/VirtoCommerce.Seo.Data.SqlServer.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Seo.Data\VirtoCommerce.Seo.Data.csproj" />

--- a/src/VirtoCommerce.Seo.Data/ExportImport/SeoExportImport.cs
+++ b/src/VirtoCommerce.Seo.Data/ExportImport/SeoExportImport.cs
@@ -29,12 +29,12 @@ public sealed class SeoExportImport(
         await using var sw = new StreamWriter(outStream, Encoding.UTF8);
         await using var writer = new JsonTextWriter(sw);
 
-        await writer.WriteStartObjectAsync();
+        await writer.WriteStartObjectAsync(cancellationToken);
 
         await ExportRedirectRules(writer, progressCallback, cancellationToken);
         await ExportBrokenLinks(writer, progressCallback, cancellationToken);
 
-        await writer.WriteEndObjectAsync();
+        await writer.WriteEndObjectAsync(cancellationToken);
     }
 
     public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
@@ -49,7 +49,7 @@ public sealed class SeoExportImport(
         var linksTotalCount = 0;
 
         const int batchSize = 100;
-        while (await reader.ReadAsync())
+        while (await reader.ReadAsync(cancellationToken))
         {
             if (reader.TokenType == JsonToken.PropertyName)
             {
@@ -57,15 +57,15 @@ public sealed class SeoExportImport(
 
                 if (readerValueString.EqualsIgnoreCase("RedirectRulesTotalCount"))
                 {
-                    rulesTotalCount = await reader.ReadAsInt32Async() ?? 0;
+                    rulesTotalCount = await reader.ReadAsInt32Async(cancellationToken) ?? 0;
                 }
                 else if (readerValueString.EqualsIgnoreCase("RedirectRules"))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    await reader.ReadAsync();
+                    await reader.ReadAsync(cancellationToken);
                     if (reader.TokenType == JsonToken.StartArray)
                     {
-                        await reader.ReadAsync();
+                        await reader.ReadAsync(cancellationToken);
 
                         var redirectRules = new List<RedirectRule>();
                         var rulesCount = 0;
@@ -75,7 +75,7 @@ public sealed class SeoExportImport(
                             redirectRules.Add(redirectRule);
                             rulesCount++;
 
-                            await reader.ReadAsync();
+                            await reader.ReadAsync(cancellationToken);
                         }
 
                         cancellationToken.ThrowIfCancellationRequested();
@@ -94,15 +94,15 @@ public sealed class SeoExportImport(
                 }
                 else if (readerValueString.EqualsIgnoreCase("BrokenLinksTotalCount"))
                 {
-                    linksTotalCount = await reader.ReadAsInt32Async() ?? 0;
+                    linksTotalCount = await reader.ReadAsInt32Async(cancellationToken) ?? 0;
                 }
                 else if (readerValueString.EqualsIgnoreCase("BrokenLinks"))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    await reader.ReadAsync();
+                    await reader.ReadAsync(cancellationToken);
                     if (reader.TokenType == JsonToken.StartArray)
                     {
-                        await reader.ReadAsync();
+                        await reader.ReadAsync(cancellationToken);
 
                         var brokenLinks = new List<BrokenLink>();
                         var linksCount = 0;
@@ -112,7 +112,7 @@ public sealed class SeoExportImport(
                             brokenLinks.Add(brokenLink);
                             linksCount++;
 
-                            await reader.ReadAsync();
+                            await reader.ReadAsync(cancellationToken);
                         }
 
                         cancellationToken.ThrowIfCancellationRequested();
@@ -143,13 +143,13 @@ public sealed class SeoExportImport(
 
         var rules = await redirectRuleSearchService.SearchAsync(new RedirectRuleSearchCriteria { Take = 0 });
         var rulesCount = rules.TotalCount;
-        await writer.WritePropertyNameAsync("RedirectRulesTotalCount");
-        await writer.WriteValueAsync(rulesCount);
+        await writer.WritePropertyNameAsync("RedirectRulesTotalCount", cancellationToken);
+        await writer.WriteValueAsync(rulesCount, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        await writer.WritePropertyNameAsync("RedirectRules");
-        await writer.WriteStartArrayAsync();
+        await writer.WritePropertyNameAsync("RedirectRules", cancellationToken);
+        await writer.WriteStartArrayAsync(cancellationToken);
 
         const int batchSize = 100;
 
@@ -160,14 +160,14 @@ public sealed class SeoExportImport(
             {
                 jsonSerializer.Serialize(writer, rule);
             }
-            await writer.FlushAsync();
+            await writer.FlushAsync(cancellationToken);
             progressInfo.Description = $"{Math.Min(rulesCount, i + batchSize)} of {rulesCount} redirect rules exported";
             progressCallback(progressInfo);
             cancellationToken.ThrowIfCancellationRequested();
         }
-        await writer.WriteEndArrayAsync();
+        await writer.WriteEndArrayAsync(cancellationToken);
 
-        await writer.FlushAsync();
+        await writer.FlushAsync(cancellationToken);
 
     }
 
@@ -181,13 +181,13 @@ public sealed class SeoExportImport(
 
         var links = await brokenLinkSearchService.SearchAsync(new BrokenLinkSearchCriteria { Take = 0 });
         var linksCount = links.TotalCount;
-        await writer.WritePropertyNameAsync("BrokenLinksTotalCount");
-        await writer.WriteValueAsync(linksCount);
+        await writer.WritePropertyNameAsync("BrokenLinksTotalCount", cancellationToken);
+        await writer.WriteValueAsync(linksCount, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        await writer.WritePropertyNameAsync("BrokenLinks");
-        await writer.WriteStartArrayAsync();
+        await writer.WritePropertyNameAsync("BrokenLinks", cancellationToken);
+        await writer.WriteStartArrayAsync(cancellationToken);
 
         const int batchSize = 100;
 
@@ -198,13 +198,13 @@ public sealed class SeoExportImport(
             {
                 jsonSerializer.Serialize(writer, member);
             }
-            await writer.FlushAsync();
+            await writer.FlushAsync(cancellationToken);
             progressInfo.Description = $"{Math.Min(linksCount, i + batchSize)} of {linksCount} broken links exported";
             progressCallback(progressInfo);
         }
-        await writer.WriteEndArrayAsync();
+        await writer.WriteEndArrayAsync(cancellationToken);
 
-        await writer.FlushAsync();
+        await writer.FlushAsync(cancellationToken);
     }
 
 }

--- a/src/VirtoCommerce.Seo.Data/ExportImport/SeoExportImport.cs
+++ b/src/VirtoCommerce.Seo.Data/ExportImport/SeoExportImport.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using VirtoCommerce.Platform.Core.Common;
@@ -21,7 +22,7 @@ public sealed class SeoExportImport(
 {
 
     public async Task ExportAsync(Stream outStream, ExportImportOptions options,
-        Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -36,7 +37,7 @@ public sealed class SeoExportImport(
         await writer.WriteEndObjectAsync();
     }
 
-    public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -132,7 +133,7 @@ public sealed class SeoExportImport(
         }
     }
 
-    private async Task ExportRedirectRules(JsonTextWriter writer, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    private async Task ExportRedirectRules(JsonTextWriter writer, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         var progressInfo = new ExportImportProgressInfo { Description = "loading data..." };
         progressCallback(progressInfo);
@@ -170,7 +171,7 @@ public sealed class SeoExportImport(
 
     }
 
-    private async Task ExportBrokenLinks(JsonTextWriter writer, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    private async Task ExportBrokenLinks(JsonTextWriter writer, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         var progressInfo = new ExportImportProgressInfo { Description = "loading data..." };
         progressCallback(progressInfo);

--- a/src/VirtoCommerce.Seo.Data/VirtoCommerce.Seo.Data.csproj
+++ b/src/VirtoCommerce.Seo.Data/VirtoCommerce.Seo.Data.csproj
@@ -7,8 +7,8 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Seo.Core\VirtoCommerce.Seo.Core.csproj" />

--- a/src/VirtoCommerce.Seo.Web/Module.cs
+++ b/src/VirtoCommerce.Seo.Web/Module.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.AspNetCore.Builder;
@@ -120,13 +121,13 @@ public class Module : IModule, IHasConfiguration, IExportSupport, IImportSupport
     }
 
     public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-        ICancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         await _appBuilder.ApplicationServices.GetRequiredService<SeoExportImport>().ExportAsync(outStream, options, progressCallback, cancellationToken);
     }
 
     public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-        ICancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         await _appBuilder.ApplicationServices.GetRequiredService<SeoExportImport>().ImportAsync(inputStream, options, progressCallback, cancellationToken);
     }

--- a/src/VirtoCommerce.Seo.Web/module.manifest
+++ b/src/VirtoCommerce.Seo.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1004.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1016.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
   </dependencies>
 

--- a/src/VirtoCommerce.Seo.Web/package-lock.json
+++ b/src/VirtoCommerce.Seo.Web/package-lock.json
@@ -380,15 +380,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -472,9 +473,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -852,6 +853,23 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -1313,10 +1331,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1335,9 +1354,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1608,9 +1627,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1628,7 +1647,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1714,25 +1733,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -1814,27 +1814,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -1866,16 +1845,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shallow-clone": {
@@ -2001,16 +1970,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -2024,10 +1992,37 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
           "optional": true
         },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
         "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -2070,15 +2065,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {


### PR DESCRIPTION
Part of **Stable 15** (Wave 1). Builds against the published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) from nuget.org.

- Platform -> **3.1039.0**; module version -> **3.1004.0**.
- `ICancellationToken` -> `System.Threading.CancellationToken` migration.\n- `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches platform export/import contracts and bulk redirect/broken-link I/O; behavior should match platform 3.1039.0 but warrants regression on import/export cancel paths.
> 
> **Overview**
> **Stable 15** alignment: VirtoCommerce platform packages and `module.manifest` `platformVersion` move from **3.1016.0** to **3.1039.0** across Core, Data, and provider projects.
> 
> Export/import follows the platform API change: **`ICancellationToken` is replaced with `System.Threading.CancellationToken`** on `Module` and `SeoExportImport`, and Newtonsoft **`JsonTextWriter` / `JsonTextReader` async calls** now pass `cancellationToken` so long-running SEO data export/import can be cancelled cooperatively.
> 
> The Web **`package-lock.json`** refresh is dev-tooling only (e.g. `ajv`, `postcss`, `terser-webpack-plugin`); it does not change runtime SEO behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298256d3b9e6245000314332c10e67f5a3d1415a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Seo_3.1004.0-pr-21-2982.zip